### PR TITLE
fix function scope issue + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can also execute ga command queue by calling executeEvent.  It's also possib
 ```js
 // send by default tracker
 this.props.i13n.executeEvent('command', {
-    command: 'send',
+    commandName: 'send',
     arguments: [
         hitType,
         [...fields],
@@ -162,7 +162,7 @@ this.props.i13n.executeEvent('command', {
 // send by specific tracker
 this.props.i13n.executeEvent('command', {
     tracker: 'myTracker', // tracker name: myTracker
-    command: 'send',
+    commandName: 'send',
     arguments: [
        ...
     ]
@@ -170,7 +170,7 @@ this.props.i13n.executeEvent('command', {
 
 // require on default tracker
 this.props.i13n.executeEvent('command', {
-    command: 'require',
+    commandName: 'require',
     arguments: [
         pluginName,
         [pluginOptions]
@@ -180,7 +180,7 @@ this.props.i13n.executeEvent('command', {
 // require plugin for specific tracker
 this.props.i13n.executeEvent('command', {
     tracker: 'myTracker',
-    command: 'require',
+    commandName: 'require',
     arguments: [
        ...
     ]

--- a/index.client.js
+++ b/index.client.js
@@ -3,6 +3,10 @@ var DEFAULT_CATEGORY = 'all';
 var DEFAULT_ACTION = 'click';
 var DEFAULT_LABEL = '';
 
+var _command = function (payload, callback) {
+    ga.apply(this, [(payload.tracker ? (payload.tracker + '.') : '') + payload.commandName].concat(payload.arguments));
+    callback && callback();
+};
 /**
  * @class ReactI13nGoogleAnalytics
  * @param {String} tracking id
@@ -51,7 +55,7 @@ ReactI13nGoogleAnalytics.prototype.getPlugin = function () {
              * @param {Function} calback callback function
              */
             pageview: function (payload, callback) {
-                this.command({
+                _command.call(this, {
                     tracker: payload.tracker || '',
                     commandName: 'send',
                     arguments: [
@@ -88,7 +92,7 @@ ReactI13nGoogleAnalytics.prototype.getPlugin = function () {
                     params.push({
                         hitCallback: callback
                     });
-                    this.command({
+                    _command.call(this, {
                         tracker: model.tracker || '',
                         commandName: 'send',
                         arguments: params
@@ -106,11 +110,7 @@ ReactI13nGoogleAnalytics.prototype.getPlugin = function () {
              * @param {Object} payload.commandName command
              * @param {Function} calback callback function
              */
-            command: function (payload, callback) {
-                ga.apply(this, [(payload.tracker ? (payload.tracker + '.') : '') + payload.commandName].concat(payload.arguments));
-                callback && callback();
-            }
-
+            command: _command.bind(this)
         }
     };
 }


### PR DESCRIPTION
Hi @kaesonho ,
`command` do not belong to the scope of `eventHandlers` when calling from [react-i13n](https://github.com/yahoo/react-i13n/blob/32609f1ff27e5589d945d2b26e8fb0b6f393748d/src/libs/EventsQueue.js#L64), causing `this.command` undefined.
Just fix it. 
Thanks!
