### PR TITLE
Fix(pageview) - Use page as name of parameter instead of url

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ var ReactI13n = require('react-i13n').ReactI13n;
 // fire pageview at whatever you want, typically we do it at componentDidMount
 ReactI13n.getInstance().execute('pageview', {
     tracker: [tracker name], // optional
-    page: [page url], // get the page url, or keep empty to let google analytics handle it
     location: [page location], // get the page location, or keep empty to let google analytics handle it
+    url: [page url], // get the page url, or keep empty to let google analytics handle it
     title: [page title] // get the page title, or keep empty to let google analytics handle it
 });
 
 // in component (React 0.14+)
 this.props.i13n.executeEvent('pageview', {
     tracker: [tracker name], // optional
-    page: [page url],
     location: [page location],
+    url: [page url],
     title: [page title]
 });
 ```


### PR DESCRIPTION
The documentation in the README uses `page` as name and not url.
