### PR TITLE
let ga determine the default value of pageview if payload.[KEYS] is not assigned

### DIFF
--- a/index.client.js
+++ b/index.client.js
@@ -1,3 +1,4 @@
+'use strict';
 var debug = require('debug')('GAI13nPlugin');
 var DEFAULT_CATEGORY = 'all';
 var DEFAULT_ACTION = 'click';
@@ -56,17 +57,27 @@ ReactI13nGoogleAnalytics.prototype.getPlugin = function () {
              * @param {Function} calback callback function
              */
             pageview: function (payload, callback) {
+                var args = {},
+                    argsKeys = ['location', 'page', 'title'];
+
+                argsKeys.forEach(function consumer(prop) {
+                    if (payload.hasOwnProperty(prop)) {
+                        args[prop] = payload[prop];
+                    }
+                });
+
+                args.hitCallback = callback;
+                // `page` is alias to `url`
+                if (payload.hasOwnProperty('url')) {
+                    args.page = payload.url
+                }
+
                 _command.call(this, {
                     tracker: payload.tracker || '',
                     commandName: 'send',
                     arguments: [
                         'pageview',
-                        {
-                            location: payload.location,
-                            page: payload.url,
-                            title: payload.title,
-                            hitCallback: callback
-                        }
+                        args
                     ]
                 });
             },

--- a/tests/unit/index.client.js
+++ b/tests/unit/index.client.js
@@ -55,6 +55,27 @@ describe('ga plugin client', function () {
     });
 
 
+    it('ga will fire pageview beacon for pageview handler correctly for default values', function (done) {
+        var reactI13nGoogleAnalytics = new ReactI13nGoogleAnalytics('foo');
+        function beaconCallback () {
+            done();
+        }
+        global.ga = function (actionSend, actionName, options) {
+            expect(actionSend).to.eql('send');
+            expect(actionName).to.eql('pageview');
+            expect(options).to.eql(
+                {
+                    hitCallback: beaconCallback,
+                    location: '/foo'
+                }
+            );
+            options.hitCallback && options.hitCallback();
+        };
+        reactI13nGoogleAnalytics.getPlugin().eventHandlers.pageview({
+            location: '/foo'
+        }, beaconCallback);
+    });
+
     it('ga will fire pageview beacon for pageview handler with default tracker', function (done) {
         var reactI13nGoogleAnalytics = new ReactI13nGoogleAnalytics('foo');
         global.ga = function (actionSend, actionName, options) {


### PR DESCRIPTION
By default ga will determine the default value for pageview `location/page/title` if not-assign.
